### PR TITLE
Separate rpc error create from set

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -483,6 +483,8 @@ int rpc_shmem_get_fd(rpc_object_t shmem);
 off_t rpc_shmem_get_offset(rpc_object_t shmem);
 #endif
 
+rpc_object_t rpc_error_create_from_gerror(GError *g_error);
+
 void rpc_trace(const char *msg, rpc_object_t frame);
 char *rpc_get_backtrace(void);
 char *rpc_generate_v4_uuid(void);
@@ -497,6 +499,7 @@ const struct rpct_class_handler *rpc_find_class_handler(const char *name,
     rpct_class_t cls);
 
 void rpc_set_last_error(int code, const char *msg, rpc_object_t extra);
+void rpc_set_last_rpc_error(rpc_object_t rpc_error);
 void rpc_set_last_gerror(GError *error);
 void rpc_set_last_errorf(int code, const char *fmt, ...);
 rpc_connection_t rpc_connection_alloc(rpc_server_t server);

--- a/src/rpc_object.c
+++ b/src/rpc_object.c
@@ -1508,6 +1508,7 @@ rpc_error_create(int code, const char *msg, rpc_object_t extra)
 rpc_object_t
 rpc_error_create_from_gerror(GError *g_error)
 {
+	
         return (rpc_error_create(g_error->code, g_error->message, NULL));
 }
 

--- a/src/rpc_object.c
+++ b/src/rpc_object.c
@@ -1504,6 +1504,14 @@ rpc_error_create(int code, const char *msg, rpc_object_t extra)
 	return (rpc_prim_create(RPC_TYPE_ERROR, val));
 }
 
+
+rpc_object_t
+rpc_error_create_from_gerror(GError *g_error)
+{
+        return (rpc_error_create(g_error->code, g_error->message, NULL));
+}
+
+
 rpc_object_t
 rpc_error_create_with_stack(int code, const char *msg, rpc_object_t extra,
     rpc_object_t stack)

--- a/src/utils.c
+++ b/src/utils.c
@@ -134,9 +134,20 @@ rpc_set_last_gerror(GError *g_error)
 {
 	rpc_object_t error;
 
-	error = rpc_error_create(g_error->code, g_error->message, NULL);
+	error = rpc_error_create_from_gerror(g_error);
 	g_private_replace(&rpc_last_error, error);
 }
+
+
+void
+rpc_set_last_rpc_error(rpc_object_t rpc_error)
+{
+
+	if (rpc_get_type(rpc_error) != RPC_TYPE_ERROR)
+		return;
+        g_private_replace(&rpc_last_error, rpc_error);
+}
+
 
 rpc_object_t
 rpc_get_last_error(void)


### PR DESCRIPTION
Added the ability to set an rpc error independently of where and how it was created.