### PR TITLE
Regex free

### DIFF
--- a/src/rpc_typing.c
+++ b/src/rpc_typing.c
@@ -897,7 +897,6 @@ rpct_read_property(struct rpct_file *file, struct rpct_interface *iface,
 	}
 
 	g_hash_table_insert(iface->members, g_strdup(name), prop);
-	g_match_info_free(match);
 	ret = 0;
 
 error:


### PR DESCRIPTION
The Glib regex implementation and documentation are very muddy. It appears that the match object has been created and must be freed even if there is no match, and matches extracted from the match object have been strndup'd and must be freed. These changes in rpc_typing.c address that. 