### PR TITLE
Allow the user to specify the python version to compile for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 export CC := clang
 export CXX := clang++
-PYTHON_VERSION := python3
+PYTHON_VERSION ?= python3
 PREFIX ?= /usr/local
 BUILD_PYTHON ?= ON
 BUILD_CPLUSPLUS ?= OFF


### PR DESCRIPTION
This still needs the `setup.py` to add `enum34` as a requirement if the user is running Python<3.4