### PR TITLE
Separate serialization

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -56,6 +56,7 @@
 #define	RPC_TRANSPORT_NO_SERIALIZE		(1 << 0)
 #define	RPC_TRANSPORT_CREDENTIALS		(1 << 1)
 #define RPC_TRANSPORT_FD_PASSING		(1 << 2)
+#define	RPC_TRANSPORT_NO_RPCT_SERIALIZE		(1 << 3)
 
 #if RPC_DEBUG
 #define debugf(...) 				\

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -734,11 +734,7 @@ rpc_recv_msg(struct rpc_connection *conn, const void *frame, size_t len,
 		return (-1);
 	}
 
-	if ((conn->rco_flags & RPC_TRANSPORT_NO_SERIALIZE) == 0) {
-		msgt = rpct_deserialize(msg);
-		rpc_release(msg);
-	} else
-		msgt = msg;
+	msgt = rpct_deserialize(msg);
 
 	if (msgt == NULL) {
 		if (conn->rco_error_handler != NULL)
@@ -750,6 +746,7 @@ rpc_recv_msg(struct rpc_connection *conn, const void *frame, size_t len,
 	if (creds != NULL)
 		conn->rco_creds = *creds;
 
+	rpc_release(msg);
 	rpc_restore_fds(msgt, fds, nfds);
 	rpc_connection_dispatch(conn, msgt);
 	return (0);
@@ -899,7 +896,7 @@ rpc_send_frame(rpc_connection_t conn, rpc_object_t frame)
 	size_t len = 0, nfds = 0;
 	int ret;
 
-	if ((conn->rco_flags & RPC_TRANSPORT_NO_SERIALIZE) == 0) {
+	if ((conn->rco_flags & RPC_TRANSPORT_NO_RPCT_SERIALIZE) == 0) {
 		tmp = rpct_serialize(frame);
 		rpc_release(frame);
 		frame = tmp;

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -900,6 +900,7 @@ rpc_send_frame(rpc_connection_t conn, rpc_object_t frame)
 		tmp = rpct_serialize(frame);
 		rpc_release(frame);
 		frame = tmp;
+		buf = tmp;
 	}
 
 #ifdef RPC_TRACE

--- a/src/transport/loopback.c
+++ b/src/transport/loopback.c
@@ -308,7 +308,8 @@ struct rpc_transport loopback_transport = {
 	.connect = loopback_connect,
 	.listen = loopback_listen,
 	.is_fd_passing = loopback_supports_fd_passing,
-    	.flags = RPC_TRANSPORT_NO_SERIALIZE | RPC_TRANSPORT_FD_PASSING
+	.flags = RPC_TRANSPORT_NO_SERIALIZE | RPC_TRANSPORT_FD_PASSING |
+	    RPC_TRANSPORT_NO_RPCT_SERIALIZE
 };
 
 DECLARE_TRANSPORT(loopback_transport);


### PR DESCRIPTION
This commit separates transport flags for serializing objects with msgpack (used by transports that cross process or machine boundaries excepting xpc which has its own mechanism) and calling rpct_serialize to allow object types particularly for non-primitive objects to be transferred with the objects. It also restores rpct deserialization for loopback which has the side effect of managing some object refcounts.