### PR TITLE
switch a build setting to silence warnings

### DIFF
--- a/bindings/objective-c/librpc.xcodeproj/project.pbxproj
+++ b/bindings/objective-c/librpc.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 				LIBRARY_SEARCH_PATHS = ../../../dest/usr/lib/;
 				OTHER_LDFLAGS = "-lrpc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "librpc/librpc-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -463,6 +464,7 @@
 				LIBRARY_SEARCH_PATHS = ../../../dest/usr/lib/;
 				OTHER_LDFLAGS = "-lrpc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "librpc/librpc-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				USER_HEADER_SEARCH_PATHS = "";


### PR DESCRIPTION
Silences annoying Xcode warnings.
99.99% sure this change is benign. 