### PR TITLE
Close an inbound call in rpc_function_end if already aborted and ended.

### DIFF
--- a/src/rpc_service.c
+++ b/src/rpc_service.c
@@ -559,9 +559,11 @@ rpc_function_end_impl(void *cookie)
 			rpc_function_error(call, ECONNRESET,
                             "Call aborted");
 			call->rc_ended = true;
+			g_mutex_unlock(&call->rc_mtx);
+		} else {
+			g_mutex_unlock(&call->rc_mtx);
+			rpc_connection_close_inbound_call(call);
 		}
-
-		g_mutex_unlock(&call->rc_mtx);
 		return;
 	}
 


### PR DESCRIPTION
Fixes a problem where an aborted query never gets removed from a server connection.