### PR TITLE
Mark some more counters volatile and tweak an assert.

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -315,10 +315,10 @@ struct rpc_server
 	bool			rs_threaded_teardown;
         rpc_object_t            rs_error;
 	volatile uint		rs_refcnt;
-	uint			rs_conn_made;
-	uint			rs_conn_refused;
-	uint			rs_conn_closed;
-	uint			rs_conn_aborted;
+	volatile uint		rs_conn_made;
+	volatile uint		rs_conn_refused;
+	volatile uint		rs_conn_closed;
+	volatile uint		rs_conn_aborted;
 	rpc_object_t 		rs_params;
 	rpc_server_ev_handler_t rs_event_handler;
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -315,10 +315,10 @@ struct rpc_server
 	bool			rs_threaded_teardown;
         rpc_object_t            rs_error;
 	volatile uint		rs_refcnt;
-	volatile uint		rs_conn_made;
-	volatile uint		rs_conn_refused;
+	uint			rs_conn_made;
+	uint			rs_conn_refused;
 	volatile uint		rs_conn_closed;
-	volatile uint		rs_conn_aborted;
+	uint			rs_conn_aborted;
 	rpc_object_t 		rs_params;
 	rpc_server_ev_handler_t rs_event_handler;
 

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -79,7 +79,6 @@ static int rpc_connection_subscribe_event_locked(rpc_connection_t, const char *,
 static struct rpc_subscription *rpc_connection_find_subscription(rpc_connection_t,
     const char *, const char *, const char *);
 static void rpc_connection_free_resources(rpc_connection_t);
-static int rpc_connection_abort(void *);
 static void rpc_connection_release_call(struct rpc_call *call);
 static int cancel_timeout_locked(rpc_call_t call);
 static void rpc_connection_set_default_fn_handlers(rpc_connection_t);

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -1373,7 +1373,7 @@ rpc_connection_do_close(rpc_connection_t conn, rpc_close_source_t source)
 		g_mutex_unlock(&conn->rco_mtx);
 
 	} else if (conn->rco_server != NULL) {
-		conn->rco_server->rs_conn_closed++;
+		g_atomic_int_inc(&conn->rco_server->rs_conn_closed);
 		conn->rco_released = true;
 		g_mutex_unlock(&conn->rco_mtx);
 

--- a/src/rpc_server.c
+++ b/src/rpc_server.c
@@ -390,8 +390,8 @@ rpc_server_release(rpc_server_t server)
 	}
 	server->rs_refcnt--;
 	if (server->rs_refcnt == 1)
-		g_assert(server->rs_conn_made ==
-		    server->rs_conn_closed);
+		g_assert(server->rs_closed || (server->rs_conn_made ==
+		    server->rs_conn_closed));
 	g_mutex_unlock(&server->rs_mtx);
 }
 

--- a/src/rpc_server.c
+++ b/src/rpc_server.c
@@ -389,9 +389,12 @@ rpc_server_release(rpc_server_t server)
 		return;
 	}
 	server->rs_refcnt--;
-	if (server->rs_refcnt == 1)
+	if (server->rs_refcnt == 1) {
+		/* rs_conn_closed increments outside of server control */
 		g_assert(server->rs_closed || (server->rs_conn_made ==
-		    server->rs_conn_closed));
+		    g_atomic_int_get(&server->rs_conn_closed)));
+	}
+
 	g_mutex_unlock(&server->rs_mtx);
 }
 


### PR DESCRIPTION
Fix a source of crashes when running under high thread activity (primarily for running librpc test_suite).