### PR TITLE
Add initialization of the new Client object when wrapping it

### DIFF
--- a/bindings/python/src/client.pxi
+++ b/bindings/python/src/client.pxi
@@ -36,6 +36,7 @@ cdef class Client(Connection):
         cdef Client ret
 
         ret = Client.__new__(Client)
+        super(Client, ret).__init__()
         ret.borrowed = True
         ret.connection = rpc_client_get_connection(ptr)
         return ret


### PR DESCRIPTION
@jceel Not sure if this is the proper way to deal with this issue (https://bugs.twoporeguys.com/issues/10317). but it does seem to resolve it