### PR TITLE
Add bool to bindings

### DIFF
--- a/bindings/objective-c/librpc/librpc.m
+++ b/bindings/objective-c/librpc/librpc.m
@@ -52,7 +52,13 @@
         } else if ([value isKindOfClass:[NSNumber class]]) {
             if (strcmp([value objCType], @encode(BOOL)) == 0) {
                 _obj = rpc_bool_create([(NSNumber *)value boolValue]);
-            } else {
+            } else if (strcmp([value objCType], @encode(int)) == 0) {
+                _obj = rpc_int64_create([(NSNumber *)value integerValue]);
+            } else if (strcmp([value objCType], @encode(uint)) == 0) {
+                _obj = rpc_int64_create([(NSNumber *)value unsignedIntegerValue]);
+            } else if (strcmp([value objCType], @encode(double)) == 0) {
+                _obj = rpc_double_create([(NSNumber *)value doubleValue]);
+            } else { // default case 
                 _obj = rpc_int64_create([(NSNumber *)value integerValue]);
             }
         } else if ([value isKindOfClass:[NSString class]]) {

--- a/bindings/objective-c/librpc/librpc.m
+++ b/bindings/objective-c/librpc/librpc.m
@@ -50,7 +50,11 @@
         } else if ([value isKindOfClass:[RPCObject class]]) {
             _obj = rpc_retain([(RPCObject *)value nativeValue]);
         } else if ([value isKindOfClass:[NSNumber class]]) {
-            _obj = rpc_int64_create([(NSNumber *)value integerValue]);
+            if (strcmp([value objCType], @encode(BOOL)) == 0) {
+                _obj = rpc_bool_create([(NSNumber *)value boolValue]);
+            } else {
+                _obj = rpc_int64_create([(NSNumber *)value integerValue]);
+            }
         } else if ([value isKindOfClass:[NSString class]]) {
             _obj = rpc_string_create([(NSString *)value UTF8String]);
         } else if ([value isKindOfClass:[NSDate class]]) {


### PR DESCRIPTION
We would like to correctly type the number values coming into librpc, however objective c's NSNumber makes that difficult by not explicitly keeping track of the input types. The method used here is not bullet proof as it does not cover all possible encodings and may fail [discussed here ](https://stackoverflow.com/questions/2518761/get-type-of-nsnumber). In the case of failure we default back to the original int 64. 