### PR TITLE
Short term fixes for som IPv6 and broader domain sockets support usin…

### DIFF
--- a/contrib/libyuarel/yuarel.c
+++ b/contrib/libyuarel/yuarel.c
@@ -165,7 +165,7 @@ yuarel_parse(struct yuarel *url, char *u)
 			return -1;
 		}
 		url->host = u;
-		if (url->host[0] == '/' && !strcmp(url->scheme, "unix"))
+		if (!strcmp(url->scheme, "unix"))
 			return 0;
 
 		/* (Path) */


### PR DESCRIPTION
…g the yuarel parser.

It supports the tcp://[::]:5001 listening server we use. Will need to be modified for broader IPv6 support and if we move to a different parser. 