### PR TITLE
Bug/check conn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,11 +341,11 @@ if(BUILD_TESTS)
 			tests/tests.h
 			tests/main.c
 			tests/api/bus.c
-#			tests/api/client.c
+			tests/api/client.c
 			tests/api/connection.c
 			tests/api/object.c
 			tests/api/query.c
-#			tests/api/serializer.c
+			tests/api/serializer.c
 			tests/api/server.c
 			tests/api/service.c
 			tests/api/typing.c

--- a/bindings/objective-c/librpc/librpc.m
+++ b/bindings/objective-c/librpc/librpc.m
@@ -35,7 +35,7 @@
 
 #pragma mark - RPCObject
 @interface RPCObject ()
-@property (nonatomic, readonly, unsafe_unretained) rpc_object_t obj;
+@property (nonatomic, readonly, assign) rpc_object_t obj;
 
 @end
 

--- a/bindings/objective-c/librpc/librpc.m
+++ b/bindings/objective-c/librpc/librpc.m
@@ -35,7 +35,7 @@
 
 #pragma mark - RPCObject
 @interface RPCObject ()
-@property (nonatomic, readonly, assign) rpc_object_t obj;
+@property (nonatomic, readonly, unsafe_unretained) rpc_object_t obj;
 
 @end
 

--- a/include/rpc/connection.h
+++ b/include/rpc/connection.h
@@ -292,11 +292,14 @@ int rpc_connection_unsubscribe_event(_Nonnull rpc_connection_t conn,
  *
  * Each time an event occurs, a handler block is going to be called.
  *
+ * If the connection is no longer valid a NULL cookie will be returned.
+ *
  * @param conn Connection to register an event handler for
  * @param name Name of an event to be handled
  * @param handler Event handler of rpc_handler_t type
+ * @return Cookie for @ref rpc_connection_unregister_event_handler or NULL.
  */
-void *_Nonnull rpc_connection_register_event_handler(
+void *_Nullable rpc_connection_register_event_handler(
     _Nonnull rpc_connection_t conn, const char *_Nullable path,
     const char *_Nullable interface, const char *_Nonnull name,
     _Nullable rpc_handler_t handler);

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -1726,8 +1726,12 @@ rpc_connection_register_event_handler(rpc_connection_t conn, const char *path,
 	struct rpc_subscription *sub;
 	struct rpc_subscription_handler *rsh;
 
-	if (!rpc_connection_retain_if_open(conn))
+	//if (!rpc_connection_retain_if_open(conn))
+		//return (NULL);
+	if (!rpc_connection_retain_if_open(conn)) {
+		fprintf(stderr, "register_event_handler RETURNING null\n");
 		return (NULL);
+	}
 
 	g_mutex_lock(&conn->rco_subscription_mtx);
 
@@ -1738,6 +1742,10 @@ rpc_connection_register_event_handler(rpc_connection_t conn, const char *path,
 	rsh->rsh_handler = Block_copy(handler);
 	g_ptr_array_add(sub->rsu_handlers, rsh);
 	g_mutex_unlock(&conn->rco_subscription_mtx);
+
+	if (conn->rco_refcnt == 1)
+		fprintf(stderr, "CONN WOULD BE GONE\n");
+
 	rpc_connection_release(conn);
 	return (rsh);
 }

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -1499,8 +1499,6 @@ rpc_connection_do_close(rpc_connection_t conn, rpc_close_source_t source)
 
 		/* if server isn't closed this will undo server's ref */
 		rpc_server_disconnect(conn->rco_server, conn);
-		/* undo connection's ref on server */
-		rpc_server_release(conn->rco_server);
 	}
 	/* undo connection's initial reference */
 	rpc_connection_release(conn);
@@ -1558,6 +1556,11 @@ rpc_connection_release(rpc_connection_t conn)
 
 		conn->rco_refcnt = -1;
 		g_mutex_unlock(&conn->rco_ref_mtx);
+
+		if (conn->rco_server != NULL) {
+			/* undo connection's ref on server */
+			rpc_server_release(conn->rco_server);
+		}
 		g_free(conn);
 		return (0);
 	}

--- a/src/rpc_service.c
+++ b/src/rpc_service.c
@@ -81,7 +81,7 @@ rpc_context_tp_handler(gpointer data, gpointer user_data)
 	struct rpc_if_method *method = call->rc_if_method;
 	rpc_object_t result;
 
-	if (call->rc_conn->rco_closed) {
+	if (!rpc_connection_is_open(call->rc_conn)) {
 		debugf("Can't dispatch call, conn %p closed", call->rc_conn);
 		rpc_connection_close_inbound_call(call);
 		return;

--- a/src/rpc_typing.c
+++ b/src/rpc_typing.c
@@ -630,14 +630,16 @@ rpct_typei_is_compatible(struct rpct_typei *decl, struct rpct_typei *type)
 	if (!compatible)
 		return (false);
 
-	/*for (guint i = 0; i < type->specializations->len; i++) {
+#if 0
+	for (guint i = 0; i < type->specializations->len; i++) {
 		compatible = rpct_type_is_compatible(
 		    g_ptr_array_index(decl->specializations, i),
 		    g_ptr_array_index(type->specializations, i));
 
 		if (!compatible)
 			break;
-	}*/
+	}
+#endif
 
 	return (compatible);
 }
@@ -1385,7 +1387,8 @@ rpct_validate_instance(struct rpct_typei *typei, rpc_object_t obj,
 	}
 
 	/* Step 2: check type */
-	if (!rpct_typei_is_compatible(raw_typei, obj->ro_typei)) {
+	if (!rpct_typei_is_compatible(raw_typei,
+	    rpct_unwind_typei(obj->ro_typei))) {
 		rpct_add_error(errctx, NULL,
 		    "Incompatible type %s, should be %s",
 		    obj->ro_typei->canonical_form,

--- a/tests/api/client.c
+++ b/tests/api/client.c
@@ -277,9 +277,9 @@ thread_mestream_func (gpointer data)
 	rpc_context_t ctx = NULL;
 	rpc_object_t result;
 	rpc_object_t value;
-        __block GRand *rand = g_rand_new ();
-        __block gint n = g_rand_int_range (rand, 1, STREAMS);
-	__block char *str = g_malloc(27);
+        GRand *rand = g_rand_new ();
+        gint n = g_rand_int_range (rand, 1, STREAMS);
+	char *str = g_malloc(27);
 	__block int cnt = 0;
 	rpc_call_t call;
 
@@ -314,7 +314,8 @@ thread_mestream_func (gpointer data)
 
 	value = rpc_object_pack("[s,i]", "callme", (int64_t)n);
 	call = rpc_connection_call(conn, NULL, NULL, "stream-me", value, NULL);
-	g_assert(call != NULL);
+	if (call == NULL)
+		g_thread_exit (GINT_TO_POINTER (1));
 	rpc_call_wait(call);
 	result = rpc_call_result(call);
 

--- a/tests/api/server.c
+++ b/tests/api/server.c
@@ -68,7 +68,7 @@ struct u {
 
 typedef struct {
 	rpc_context_t	ctx;
-        int 		iuri;
+	int 		iuri;
 	volatile int 	count;
 	rpc_server_t 	srv;
 	bool 		resume;
@@ -97,7 +97,7 @@ server_test_basic_set_up(server_fixture *fixture, gconstpointer user_data)
 {
 
 	fixture->ctx = rpc_context_create();
-        fixture->iuri = (int)user_data;
+	fixture->iuri = (int)user_data;
 	fixture->count = 0;
 	fixture->srv = NULL;
 }
@@ -107,25 +107,25 @@ valid_server_set_up(server_fixture *fixture, gconstpointer u_data)
 {
 
 	fixture->ctx = rpc_context_create();
-        fixture->iuri = (int)u_data;
+	fixture->iuri = (int)u_data;
 	fixture->count = 0;
 	fixture->iclose = 0;
 
-        rpc_context_register_block(fixture->ctx, base.interface, "hi",
-            NULL, ^(void *cookie __unused, rpc_object_t args) {
+	rpc_context_register_block(fixture->ctx, base.interface, "hi",
+	    NULL, ^(void *cookie __unused, rpc_object_t args) {
 		g_atomic_int_inc(&fixture->count);
-                return rpc_string_create_with_format("hello %s!",
-                    rpc_array_get_string(args, 0));
-            });
+		return rpc_string_create_with_format("hello %s!",
+		    rpc_array_get_string(args, 0));
+	    });
 
-        rpc_context_register_block(fixture->ctx, base.interface, "block",
-            NULL, ^(void *cookie __unused,
+	rpc_context_register_block(fixture->ctx, base.interface, "block",
+	    NULL, ^(void *cookie __unused,
 		rpc_object_t args __unused) {
 		g_atomic_int_inc(&fixture->called);
 		sleep(fixture->called * 2);
 		g_atomic_int_inc(&fixture->woke);
-                return (rpc_string_create("haha lol"));
-            });
+		return (rpc_string_create("haha lol"));
+	    });
 
 	rpc_context_register_block(fixture->ctx, NULL, "event",
 	    NULL, ^(void *cookie __unused, rpc_object_t args __unused) {
@@ -150,8 +150,8 @@ thread_kill_call (gpointer data)
 static void
 server_test_stream_setup(server_fixture *fix, gconstpointer u_data)
 {
-        GRand *rand = g_rand_new ();
-        gint n = g_rand_int_range (rand, 1, STREAMS);
+	GRand *rand = g_rand_new ();
+	gint n = g_rand_int_range (rand, 1, STREAMS);
 	server_fixture *fixture = fix;
 	int res;
 
@@ -166,8 +166,8 @@ server_test_stream_setup(server_fixture *fix, gconstpointer u_data)
 	else if (fixture->abort > 0)
 		fixture->abort = g_rand_int_range (rand, 1, n);
 	
-        res = rpc_context_register_block(fixture->ctx, base.interface, "stream",
-            NULL, ^rpc_object_t (void *cookie, rpc_object_t args __unused) {
+	res = rpc_context_register_block(fixture->ctx, base.interface, "stream",
+	    NULL, ^rpc_object_t (void *cookie, rpc_object_t args __unused) {
 		int cnt = 0;	
 		gint i;
 		rpc_object_t res;
@@ -202,7 +202,7 @@ server_test_stream_setup(server_fixture *fix, gconstpointer u_data)
 			rpc_function_release(cookie);
 		}
 		return (RPC_FUNCTION_STILL_RUNNING);
-            });
+	    });
 	g_assert(res == 0);
 
 }
@@ -231,9 +231,9 @@ server_test_valid_server_tear_down(server_fixture *fixture, gconstpointer user_d
 		rpc_server_close(fixture->srv);
 
 	server_wait(fixture->ctx, uris[fixture->iuri].srv);
-        rpc_context_unregister_member(fixture->ctx, NULL, "hi");
-        rpc_context_unregister_member(fixture->ctx, NULL, "block");
-        rpc_context_unregister_member(fixture->ctx, NULL, "event");
+	rpc_context_unregister_member(fixture->ctx, NULL, "hi");
+	rpc_context_unregister_member(fixture->ctx, NULL, "block");
+	rpc_context_unregister_member(fixture->ctx, NULL, "event");
 	rpc_context_free(fixture->ctx);
 }
 
@@ -281,10 +281,10 @@ thread_stream_func (gpointer data)
 		rpc_client_close(client);
 		g_thread_exit (GINT_TO_POINTER (0));
 	}
-        for (;;) {
-                rpc_call_wait(call);
+	for (;;) {
+		rpc_call_wait(call);
 
-                switch (rpc_call_status(call)) {
+		switch (rpc_call_status(call)) {
 		case RPC_CALL_STREAM_START:
 			rpc_call_continue(call, false);
 			break;
@@ -308,8 +308,8 @@ thread_stream_func (gpointer data)
 
 		default:
 			g_assert_not_reached();
-                }
-        }
+		}
+	}
 
 done:
 	rpc_call_free(call);
@@ -398,21 +398,18 @@ thread_func_event (gpointer data)
 		g_assert_cmpstr(rpc_string_get_string_ptr(args), ==, "world");
 		*resp = 1;
 	    });
-	g_assert(handle != NULL || !rpc_connection_is_open(conn));
+
 	if (handle == NULL) {
-		fprintf(stderr, "NO handle\n");
 		rpc_client_close(client);
 		g_thread_exit (GINT_TO_POINTER (1));
 	}
 	result = rpc_connection_call_simple(conn, "event", RPC_NULL_FORMAT);
 
 	if (result == NULL) {
-		fprintf(stderr, "NO result\n");
 		rpc_client_close(client);
 		g_thread_exit (GINT_TO_POINTER (1));
 
 	} else if (rpc_is_error(result)) {
-		fprintf(stderr, "BAD result\n");
 		rpc_client_close(client);
 		g_thread_exit (GINT_TO_POINTER (1));
 	}
@@ -421,7 +418,6 @@ thread_func_event (gpointer data)
 		sleep(5);
 
 	rpc_client_close(client);
-	//fprintf(stderr, "exiting\n");
 	g_thread_exit (GINT_TO_POINTER (0));
 	return (NULL);
 }
@@ -568,12 +564,12 @@ server_test_nullables(server_fixture *fixture, gconstpointer user_data)
 	rpc_call_t call2;
 
 	rpc_server_resume(fixture->srv);
-        client = rpc_client_create(uris[fixture->iuri].cli, 0);
-        if (client == NULL)
-                g_thread_exit (GINT_TO_POINTER (1));
+	client = rpc_client_create(uris[fixture->iuri].cli, 0);
+	if (client == NULL)
+		g_thread_exit (GINT_TO_POINTER (1));
  
-        conn = rpc_client_get_connection(client);
-        result = rpc_connection_call_simple(conn, "hi", "[s]", "world");
+	conn = rpc_client_get_connection(client);
+	result = rpc_connection_call_simple(conn, "hi", "[s]", "world");
 	g_assert(result != NULL && !(rpc_is_error(result)));
 	g_assert_cmpstr("hello world!", ==, rpc_string_get_string_ptr(result));
 
@@ -581,13 +577,13 @@ server_test_nullables(server_fixture *fixture, gconstpointer user_data)
 
 	call_args1 = rpc_object_pack("[s]", args[0].interface);
 	call1 = rpc_connection_call(conn, args[0].path, RPC_INTROSPECTABLE_INTERFACE,
-            "get_methods", call_args1, NULL);
+	    "get_methods", call_args1, NULL);
 	rpc_call_wait(call1);
 	g_assert(!rpc_is_error(rpc_call_result(call1)));
 
 	call_args2 = rpc_object_pack("[s]", args[1].interface);
 	call2 = rpc_connection_call(conn, args[1].path, RPC_INTROSPECTABLE_INTERFACE,
-            "get_methods", call_args2, NULL);
+	    "get_methods", call_args2, NULL);
 	rpc_call_wait(call2);
 
 	g_assert(!rpc_is_error(rpc_call_result(call2)));

--- a/tests/api/server.c
+++ b/tests/api/server.c
@@ -628,7 +628,6 @@ static void
 server_test_register()
 {
 
-/*
 	g_test_add("/server/resume/tcp", server_fixture, (void *)0,
 	    server_test_valid_server_set_up, server_test_resume,
 	    server_test_valid_server_tear_down);
@@ -663,11 +662,9 @@ server_test_register()
 	    server_test_valid_server_set_up, server_test_flush,
 	    server_test_valid_server_tear_down);
 
-*/
 	g_test_add("/server/flush/event", server_fixture, (void *)0,
 	    server_test_valid_server_set_up, server_test_event,
 	    server_test_valid_server_tear_down);
-/*
 
 	g_test_add("/server/stream/one", server_fixture, (void *)7,
 	    server_test_stream_setup, server_test_stream_run,
@@ -688,7 +685,6 @@ server_test_register()
 	g_test_add("/server/flush/loopback", server_fixture, (void *)7,
 	    server_test_valid_server_set_up, server_test_flush,
 	    server_test_valid_server_tear_down);
-*/
 }
 
 static struct librpc_test server = {

--- a/tests/api/server.c
+++ b/tests/api/server.c
@@ -184,13 +184,15 @@ server_test_stream_setup(server_fixture *fix, gconstpointer u_data)
 			if (rpc_function_yield(cookie, res) != 0)
 				break;
 		}	
-		if (fixture->kill)
-			rpc_function_retain(cookie);
+		/* retain call across call to rpc_function_end */
+		rpc_function_retain(cookie);
 		rpc_function_end(cookie);
 		if (fixture->kill) {
+			/* thread will release call */
 			thd = g_thread_new("kill", thread_kill_call, cookie);
 			g_thread_unref(thd);
 		}
+		rpc_function_release(cookie);
 		return (RPC_FUNCTION_STILL_RUNNING);
             });
 	g_assert(res == 0);

--- a/tests/api/server.c
+++ b/tests/api/server.c
@@ -145,7 +145,7 @@ server_test_stream_setup(server_fixture *fix, gconstpointer u_data)
 {
         GRand *rand = g_rand_new ();
         gint n = g_rand_int_range (rand, 1, STREAMS);
-	__block server_fixture *fixture = fix;
+	server_fixture *fixture = fix;
 	int res;
 
 	base = args[0];
@@ -191,8 +191,9 @@ server_test_stream_setup(server_fixture *fix, gconstpointer u_data)
 			/* thread will release call */
 			thd = g_thread_new("kill", thread_kill_call, cookie);
 			g_thread_unref(thd);
+		} else {
+			rpc_function_release(cookie);
 		}
-		rpc_function_release(cookie);
 		return (RPC_FUNCTION_STILL_RUNNING);
             });
 	g_assert(res == 0);


### PR DESCRIPTION
Changes for the following:
-The objective C bindings can handle a null subscription handler
-rpc_connection_register_event_handler() will 
        -ensure that the connection is valid, and if so, that it is retained while the subscription is being created
        -check the return value from creating the subscription, which may fail if the attempt to register the subscription with the server encounters a transport error
- Adds a multithreaded test for registering and getting event callbacks to test_suite

In the course of testing, the following changes were made as the result of failures or review:
-in rpc_server.c, rpc_server_close(): protect the rs_connections array while connections are being aborted. This fixes a race when the server closes while events are being emitted.
- in the rpc_connection.c connection-close code, move the call to rpc_server_release() from rpc_connection_do_close to rpc_connection_release(). This ensures that the server will not close while any connection or call structures are still in use or being cleaned up.
-replace runs of spaces with tabs where appropriate in tests/api/server.c
-better use of rpc_function_retain() in the same file when ending a call.
-change rpc_service.c rpc_context_tp_handler() to use rpc_connection_is_open() 
-replace an assert in tests/api/client where a null call might be legitimately be returned