### PR TITLE
On teardown, don't call rpc_context_free() until the server is no lon…

### DIFF
--- a/tests/api/client.c
+++ b/tests/api/client.c
@@ -531,11 +531,15 @@ static void
 client_test_tear_down(client_fixture *fixture, gconstpointer user_data)
 {
 
-	if (fixture->srv)
+	if (fixture->srv) {
 		rpc_server_close(fixture->srv);
+		while (rpc_server_find(uris_[fixture->iuri].srv, fixture->ctx) != NULL)
+			sleep(5);
+	}
 	rpc_context_unregister_member(fixture->ctx, NULL, "hi");
 	rpc_context_free(fixture->ctx);
 }
+
 
 static void
 client_test_register()


### PR DESCRIPTION
…ger in the context array.
There are cases where the client will be finished and enter test teardown while a sequence of the final call/conn/server are being cleaned up in another thread. If the server context is freed too early that cleanup can crash. This problem was solved in the server tests and that solution has been implemented here. 
