### PR TITLE
Bug/fix creds

### DIFF
--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -30,6 +30,13 @@
  *
  * This is a basic client API example, demonstrating how to handle streaming
  * and non-streaming calls.
+ *
+ * To run with the default URI:
+ * ./build/examples/client/example-client
+ * To specify the URI:
+ * ./build/examples/client/example-client  unix://test2.sock
+ * Note that the unix domain socket example requires that client and server
+ * be run from the same directory specifying the same socket.
  */
 
 #include <stdio.h>

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -61,10 +61,10 @@ main(int argc, const char *argv[])
 	int64_t num;
 	int cnt = 0;
 
-	(void)argc;
-	(void)argv;
-
-	client = rpc_client_create("tcp://127.0.0.1:5000", 0);
+	if (argc > 1)
+		client = rpc_client_create(argv[1], 0);
+	else
+		client = rpc_client_create("tcp://127.0.0.1:5000", 0);
 	if (client == NULL) {
 		result = rpc_get_last_error();
 		fprintf(stderr, "cannot connect: %s\n",

--- a/examples/client/client.c
+++ b/examples/client/client.c
@@ -81,6 +81,11 @@ main(int argc, const char *argv[])
 	printf("result = %s\n", rpc_string_get_string_ptr(result));
 	rpc_release(result);
 
+	if (rpc_connection_has_credentials(conn)) {
+		fprintf(stderr, "Remote pid is %d\n",
+		    (int)rpc_connection_get_remote_pid(conn));
+	}
+
         call = rpc_connection_call(conn, NULL, NULL, "stream", rpc_array_create(), NULL);
         if (call == NULL) {
                 fprintf(stderr, "Stream call failed\n");

--- a/src/internal.h
+++ b/src/internal.h
@@ -93,7 +93,7 @@ struct rpct_validator;
 struct rpct_error_context;
 
 typedef int (*rpc_recv_msg_fn_t)(struct rpc_connection *, const void *, size_t,
-    int *, size_t, struct rpc_credentials *);
+    int *, size_t);
 typedef int (*rpc_send_msg_fn_t)(void *, const void *, size_t, const int *, size_t);
 typedef int (*rpc_abort_fn_t)(void *);
 typedef int (*rpc_get_fd_fn_t)(void *);
@@ -102,6 +102,7 @@ typedef int (*rpc_close_fn_t)(struct rpc_connection *);
 typedef int (*rpc_accept_fn_t)(struct rpc_server *, struct rpc_connection *);
 typedef bool (*rpc_valid_fn_t)(struct rpc_server *);
 typedef int (*rpc_teardown_fn_t)(struct rpc_server *);
+typedef int (*rpc_set_creds_fn_t)(struct rpc_connection *, pid_t, uid_t, gid_t);
 
 typedef struct rpct_member *(*rpct_member_fn_t)(const char *, rpc_object_t,
     struct rpct_type *);
@@ -293,6 +294,7 @@ struct rpc_connection
 	rpc_close_fn_t		rco_close;
     	rpc_get_fd_fn_t 	rco_get_fd;
 	rpc_release_fn_t	rco_release;
+	rpc_set_creds_fn_t	rco_set_creds;
 	void *			rco_arg;
 	struct rpc_fn_callbacks rco_fn_cbs;
 };

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -83,7 +83,7 @@ static int cancel_timeout_locked(rpc_call_t call);
 static void rpc_connection_set_default_fn_handlers(rpc_connection_t);
 static inline rpc_object_t rpc_call_result_save(rpc_call_t call);
 static int rpc_connection_do_close(rpc_connection_t conn, rpc_close_source_t);
-static rpc_connection_t rpc_connection_init(void);
+static rpc_connection_t rpc_connection_init(int);
 static void rpc_abort_worker(void *arg, void *data);
 static void call_abort_locked(struct rpc_call *call);
 static bool rpc_connection_retain_if_open(rpc_connection_t conn);
@@ -1337,7 +1337,7 @@ rpc_connection_set_default_fn_handlers(rpc_connection_t conn)
 }
 
 static rpc_connection_t
-rpc_connection_init(void)
+rpc_connection_init(int flags)
 {
 	struct rpc_connection *conn = g_malloc0(sizeof(*conn));
 
@@ -1355,6 +1355,7 @@ rpc_connection_init(void)
 	conn->rco_recv_msg = rpc_recv_msg;
 	conn->rco_close = rpc_close;
 
+	conn->rco_flags = flags;
 	if (rpc_connection_supports_credentials(conn))
 		conn->rco_set_creds = rpc_set_creds;
 
@@ -1373,10 +1374,9 @@ rpc_connection_alloc(rpc_server_t server)
 	struct rpc_connection *conn = NULL;
 	GError *err = NULL;
 
-	conn = rpc_connection_init();
+	conn = rpc_connection_init(server->rs_flags);
 
 	conn->rco_uri = server->rs_uri;
-	conn->rco_flags = server->rs_flags;
 	conn->rco_server = server;
 	conn->rco_main_context = rpc_server_get_main_context(server);
 
@@ -1408,10 +1408,9 @@ rpc_connection_create(void *cookie, rpc_object_t params)
 		return (NULL);
 	}
 
-	conn = rpc_connection_init();
+	conn = rpc_connection_init(transport->flags);
 
 	conn->rco_client = client;
-	conn->rco_flags = transport->flags;
 	conn->rco_params = params;
 	conn->rco_uri = client->rci_uri;
 	conn->rco_main_context = rpc_client_get_main_context(client);

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -812,7 +812,6 @@ rpc_set_creds(rpc_connection_t conn, pid_t pid, uid_t uid, gid_t gid)
 		return (-1);
 	}
 	g_assert(rpc_connection_supports_credentials(conn));
-	g_assert(!conn->rco_has_creds);
 	g_mutex_lock(&conn->rco_mtx);
 
 	conn->rco_has_creds = true;

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -820,6 +820,10 @@ rpc_set_creds(rpc_connection_t conn, pid_t pid, uid_t uid, gid_t gid)
 	conn->rco_creds.rcc_uid = uid;
 	conn->rco_creds.rcc_gid = gid;
 
+        fprintf(stderr, "%s conn %p has creds: %d %d %d\n",
+            conn->rco_server == NULL ? "Client" : "Server",
+            conn, pid, uid, gid);
+
 	g_mutex_unlock(&conn->rco_mtx);
 	return (0);
 }

--- a/src/rpc_connection.c
+++ b/src/rpc_connection.c
@@ -820,10 +820,6 @@ rpc_set_creds(rpc_connection_t conn, pid_t pid, uid_t uid, gid_t gid)
 	conn->rco_creds.rcc_uid = uid;
 	conn->rco_creds.rcc_gid = gid;
 
-        fprintf(stderr, "%s conn %p has creds: %d %d %d\n",
-            conn->rco_server == NULL ? "Client" : "Server",
-            conn, pid, uid, gid);
-
 	g_mutex_unlock(&conn->rco_mtx);
 	return (0);
 }

--- a/src/transport/bus.c
+++ b/src/transport/bus.c
@@ -486,7 +486,7 @@ bus_process_message(void *arg, struct librpc_message *msg, void *payload,
 	switch (msg->opcode) {
 	case LIBRPC_RESPONSE:
 		conn->bc_parent->rco_recv_msg(conn->bc_parent, payload, len,
-		    NULL, 0, NULL);
+		    NULL, 0);
 		break;
 	}
 }

--- a/src/transport/fd.c
+++ b/src/transport/fd.c
@@ -175,7 +175,7 @@ fd_reader(void *arg)
 			break;
 
 		if (fdconn->parent->rco_recv_msg(fdconn->parent, frame, len,
-		    NULL, 0, NULL) != 0) {
+		    NULL, 0) != 0) {
 			g_free(frame);
 			break;
 		}

--- a/src/transport/libusb.c
+++ b/src/transport/libusb.c
@@ -637,8 +637,7 @@ usb_send_msg_impl(void *arg)
 		switch (packet.status) {
 		case LIBRPC_USB_OK:
 			conn->uc_rco->rco_recv_msg(conn->uc_rco,
-			    &packet.request, (size_t)ret, NULL,
-			    0, NULL);
+			    &packet.request, (size_t)ret, NULL, 0);
 			goto out;
 
 		case LIBRPC_USB_NOT_READY:

--- a/src/transport/loopback.c
+++ b/src/transport/loopback.c
@@ -201,7 +201,7 @@ loopback_send_msg(void *arg, const void *buf, size_t len __unused,
 
 	rpc_retain(obj);
 	ret = (peer_conn->rco_recv_msg(peer_conn, (const void *)obj, 0,
-	    (int *)fds, nfds, NULL));
+	    (int *)fds, nfds));
 	rpc_release(obj);
 	rpc_connection_release(peer_conn);
 	return (ret);

--- a/src/transport/ws.c
+++ b/src/transport/ws.c
@@ -358,7 +358,7 @@ ws_receive_message(SoupWebsocketConnection *ws __unused,
 
 	data = g_bytes_get_data(message, &len);
 	debugf("received frame: addr=%p, len=%zu", data, len);
-	conn->wc_parent->rco_recv_msg(conn->wc_parent, data, len, NULL, 0, NULL);
+	conn->wc_parent->rco_recv_msg(conn->wc_parent, data, len, NULL, 0);
 }
 
 static void

--- a/src/transport/xpc.c
+++ b/src/transport/xpc.c
@@ -280,7 +280,7 @@ xpc_connect(struct rpc_connection *conn, const char *uri_string,
 		}
 
 		rpc_object_t obj = xpc_to_rpc(msg);
-		conn->rco_recv_msg(conn, obj, 0, NULL, 0, NULL);
+		conn->rco_recv_msg(conn, obj, 0, NULL, 0);
 		rpc_release(obj);
 	});
 
@@ -324,7 +324,7 @@ xpc_listen(struct rpc_server *conn, const char *uri_string,
 			}
 
 			rpc_object_t obj = xpc_to_rpc(msg);
-			xconn->conn->rco_recv_msg(xconn->conn, obj, 0, NULL, 0, NULL);
+			xconn->conn->rco_recv_msg(xconn->conn, obj, 0, NULL, 0);
 		});
 
 		conn->rs_accept(conn, xconn->conn);


### PR DESCRIPTION
This PR makes changes to take Domain sockets credential handling out of the packet transfer  path. It also stops the Linux kernel from passing credentials in every message.