### PR TITLE
Feature/interface rwlock

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -362,7 +362,7 @@ struct rpc_interface_priv
 	char *			rip_description;
 	void *			rip_arg;
 	GHashTable *		rip_members;
-	GMutex			rip_mtx;
+	GRWLock			rip_rwlock;
 };
 
 struct rpc_property_cookie


### PR DESCRIPTION
This change replaces the interface mutex with a reader writer lock. Finding a member or iterating the interface do not require that an exclusive lock be held. Also unlocks the interface when trying to unregister a member that is not currently registered.
Ticket 10480 