### PR TITLE
get_chunk doesn't need extra retain on result, rpc_connection_call do…

### DIFF
--- a/bindings/python/src/connection.pxi
+++ b/bindings/python/src/connection.pxi
@@ -291,6 +291,7 @@ cdef class Connection(object):
         def get_chunk():
             nonlocal rpc_result
 
+            rpc_result = rpc_call_result(call)
             return Object.wrap(rpc_result).unpack()
 
         def iter_chunk():

--- a/bindings/python/src/connection.pxi
+++ b/bindings/python/src/connection.pxi
@@ -291,7 +291,6 @@ cdef class Connection(object):
         def get_chunk():
             nonlocal rpc_result
 
-            rpc_result = rpc_retain(rpc_call_result(call))
             return Object.wrap(rpc_result).unpack()
 
         def iter_chunk():


### PR DESCRIPTION
…es it.
When the result is received, the status is set to DONE and the refcount is incremented. 