### PR TITLE
Check that a connection to a bus instance has been created before clo…

### DIFF
--- a/src/transport/bus.c
+++ b/src/transport/bus.c
@@ -348,7 +348,8 @@ static int
 bus_netlink_close(struct bus_netlink *bn)
 {
 	close(bn->bn_sock);
-	bus_process_departure(bn->bn_arg);
+	if (bn->bn_arg != NULL)
+		bus_process_departure(bn->bn_arg);
 	return (0);
 }
 


### PR DESCRIPTION
…sing it.

This fixes a problem for code that communicates through the bus transport without creating a client.