### PR TITLE
rpcd register_service doesn't use a librpc.Type for the argument

### DIFF
--- a/src/rpc_rpcd_client.c
+++ b/src/rpc_rpcd_client.c
@@ -140,7 +140,7 @@ rpcd_register(const char *uri, const char *name, const char *description)
 	conn = rpc_client_get_connection(client);
 	result = rpc_connection_call_syncp(conn, "/", RPCD_MANAGER_INTERFACE,
 	    "register_service",
-	    "[<com.twoporeguys.librpc.rpcd.Service>{s,s,s}]",
+	    "[{s,s,s}]",
 	    "uri", uri,
 	    "name", name,
 	    "description", description);


### PR DESCRIPTION
rpcd register_service doesn't use a `librpc.Type` as the argument